### PR TITLE
US75118: Add --only to follow only this one URL path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -129,6 +129,7 @@ usage examples.
                           Prefer server encoding if specified. Else detect
                           encoding
       -S, --show-source   Show source of links (html) in the report.
+      -j, --only          Only (just) follow page links that match the starting URL
 
     Performance Options:
       These options can impact the performance of the crawler.

--- a/pylinkvalidator/crawler.py
+++ b/pylinkvalidator/crawler.py
@@ -379,6 +379,18 @@ class PageCrawler(object):
             element_links = html_soup.find_all(element_type)
             links.extend(self._get_links(
                 element_links, attribute, base_url_split, original_url_split))
+
+        if self.worker_config.only:
+            # filter links based on starting URL
+            filtered_links = []
+            for link in links:
+                for path in self.worker_config.match_urls:
+                    if link.url_split.path[:len(path)] == path:
+                        filtered_links.append(link)
+                        break
+                    print "filter: ", len(links), " reduced: ", len(filtered_links)
+                    links = filtered_links
+
         return links
 
     def _get_links(self, elements, attribute, base_url_split,

--- a/pylinkvalidator/models.py
+++ b/pylinkvalidator/models.py
@@ -85,7 +85,7 @@ WorkerInit = namedtuple("WorkerInit", ["worker_config", "input_queue",
 WorkerConfig = namedtuple(
     "WorkerConfig",
     ["username", "password", "types", "timeout", "parser", "strict_mode",
-     "prefer_server_encoding", "extra_headers"])
+     "prefer_server_encoding", "extra_headers", "only", "match_urls"])
 
 
 WorkerInput = namedtuple("WorkerInput", ["url_split", "should_crawl", "depth"])
@@ -200,6 +200,10 @@ class Config(UTF8Class):
         return options
 
     def _parse_config(self):
+        if self.options.only:
+            # --only implies we're only following <a> tags
+            self.options.types = 'a'
+
         self.worker_config = self._build_worker_config(self.options)
         self.accepted_hosts = self._build_accepted_hosts(
             self.options, self.start_urls)
@@ -229,10 +233,17 @@ class Config(UTF8Class):
                 if len(split) == 2:
                     headers[split[0]] = split[1]
 
+        # if --only, create a list of just the URL paths to match
+        match_urls = []
+        if options.only:
+            for url in self.start_urls:
+                o = get_clean_url_split(url)
+                match_urls.append(o.path)
+
         return WorkerConfig(
             options.username, options.password, types, options.timeout,
             options.parser, options.strict_mode,
-            options.prefer_server_encoding, headers)
+            options.prefer_server_encoding, headers, options.only, match_urls)
 
     def _build_accepted_hosts(self, options, start_urls):
         hosts = set()
@@ -380,6 +391,10 @@ class Config(UTF8Class):
             "-S", "--show-source", dest="show_source",
             action="store_true", default=False,
             help="Show source of links (html) in the report.")
+        crawler_group.add_option(
+            "-j", "--only", dest="only",
+            action="store_true", default=False,
+            help="Only follow page links that match the starting URL.")
 
         parser.add_option_group(output_group)
 


### PR DESCRIPTION
Add a new option (-j, --only) that only follows URLs that match the starting URL path.
